### PR TITLE
Adding some modifications to feed in events into FortiSOAR via FortiSIEM

### DIFF
--- a/config.json_sample
+++ b/config.json_sample
@@ -10,10 +10,12 @@
 	"tenant":"",
 	"TR_FG_MGMT_IP":"10.200.3.1",
 	"TR_FG_DEV_NAME":"FortiGate-Edge",
+	"FGT_SN": "FGXXXXXXXXXXXXXX"
 	"TR_CUSTOMER_LAN":"10.200.3.0/24",
 	"GUI_mode": "local",
 	"GUI_sshHost": "10.22.1.234",
 	"GUI_sshPort": "20200",
 	"GUI_sshUser": "admin",
-	"GUI_sshPass": "admin*1"
+	"GUI_sshPass": "admin*1",
+	"TimeZone": "+0000"
 }

--- a/scenarios/FortiSIEM/Data_Leak_Prevention/info.json
+++ b/scenarios/FortiSIEM/Data_Leak_Prevention/info.json
@@ -1,0 +1,11 @@
+{
+    "publisher": "CSE Team",
+    "name": "Data Leakage",
+    "product":"fortisiem",
+    "category":"soc_analyst",
+    "version": "1.0.0",
+    "description": "Data leakage of files: an encrypted file, a classified file, an unclassified file, and a restricted file.",
+    "device_dependency":{"dev_name":"fortigate","dev_ip":"10.16.120.254"},
+    "category": "soc_analyst",
+    "infographic": "https://github..."
+}

--- a/scenarios/FortiSIEM/Data_Leak_Prevention/scenario.json
+++ b/scenarios/FortiSIEM/Data_Leak_Prevention/scenario.json
@@ -1,0 +1,38 @@
+[
+  {
+    "sleep": -1,
+    "name": "Data Leakage Detected",
+    "source": "FSMSIM-Data-Leak-Prevention",
+    "demo_message": "1) Data Leakage: A user send an encrypted file to a trusted destination.\n  a) [Alerts view] User a.belgooda shares a secret file: top_secret.docx.\n  b) [Playbooks Logs] The File is Encrypted.\n  c) [Users View] The user is not a known offender.\n  d) [Alerts View] Destination compliant with InfoSec policy.\n  e) [Alerts > tasks View] Start Customer InfoSec Whitelist.",
+    "source_ip": "10.16.120.254",
+    "destination_ip": "",
+    "payload": "<189>date={{TR_DATE_NOW_ONLY}} time={{TR_TIME_NOW_ONLY}} devname=\"{{TR_FG_DEV_NAME}}\" devid=\"{{TR_FGT_SN}}\" logid=\"0954024577\" type=\"utm\" subtype=\"dlp\" eventtype=\"dlp\" level=\"notice\" vd=\"root\" eventtime=1591812327419319166 tz=\"{{TR_TIMEZONE}}\" filteridx=1 filtername=\"Encrypted files\" filtertype=\"encrypted\" filtercat=\"file\" severity=\"high\" policyid=5 sessionid=182388 epoch=749638347 eventid=0 srcip={{TR_ASSET_IP}} srcport=57442 srcintf=\"port3\" srcintfrole=\"lan\" dstip=\"10.200.3.250\" dstport=21 dstintf=\"port2\" dstintfrole=\"dmz\" proto=6 service=\"FTP\" user=\"a.belgooda\" authserver=\"FSSO\" filetype=\"msofficex\" direction=\"outgoing\" action=\"log-only\" filename=\"secret_doc.docx\" filesize=54784 profile=\"dlp_profile\""
+  },
+  {
+    "sleep": -1,
+    "name": "Data Leakage Detected",
+    "source": "FSMSIM-Data-Leak-Prevention",
+    "demo_message": "2) Data Leakage: A user sends a file with the classification tag of \"Top Secret\".\n  a) [Alerts View] User m.goodspeed Shares Traduction.docx with Internet recipient.\n  b) [Playbooks Logs] The file Traduction.docx data classification is: Top Secret.\n  c) [Alerts View] Severity set to Critical.\n  d) [Playbooks Logs] Playbook walkthrough.\n  e) [Alerts > Comments View/FortiGate GUI] User blocked on FortiGate.",
+    "source_ip": "10.16.120.254",
+    "destination_ip": "",
+    "payload": "<189>date={{TR_DATE_NOW_ONLY}} time={{TR_TIME_NOW_ONLY}} devname=\"{{TR_FG_DEV_NAME}}\" devid=\"{{TR_FGT_SN}}\" logid=\"0954024577\" type=\"utm\" subtype=\"dlp\" eventtype=\"dlp\" level=\"notice\" vd=\"root\" eventtime=1591815494749154664 tz=\"{{TR_TIMEZONE}}\" filteridx=3 filtername=\"watermark_private\" dlpextra=\"top_secret: Critical\" filtertype=\"watermark\" filtercat=\"file\" severity=\"high\" policyid=5 sessionid=189656 epoch=2125573460 eventid=0 srcip={{TR_ASSET_IP}} srcport=57492 srcintf=\"port3\" srcintfrole=\"lan\" dstip={{TR_MALICIOUS_IP}} dstport=21 dstintf=\"port2\" dstintfrole=\"dmz\" proto=6 service=\"FTP\" user=\"m.goodspeed\" authserver=\"FSSO\" filetype=\"msofficex\" direction=\"outgoing\" action=\"log-only\" filename=\"Traduction.docx\" filesize=96090 profile=\"dlp_profile\" infectedfilename=\"docProps/custom.xml\" infectedfilesize=473 infectedfiletype=\"html\" infectedfilelevel=1"
+  },
+  {
+    "sleep": -1,
+    "name": "Data Leakage Detected",
+    "source": "FSMSIM-Data-Leak-Prevention",
+    "demo_message": "3) Data Leakage: A user sends a file without a classification tag.\n  a) [Alerts View] User: l.kolbad sends an unclassified file: Benchmarks_f.docx over the internet.\n  b) [Playbooks Logs] Playbook Flow.\n  c) [Playbooks Logs] Analyst to set markings after investigation.\n  d) [Users View] Look for the user in the Tracking DB.\n  e) [Users View] Update Tracking DB: open User page, show security ID Value.\n  f) [Playbooks View] User is a repeated Offender => Find previous offenses.\n  g) [Alerts > Tasks View] Start Repeated Offense procedure.",
+    "source_ip": "10.16.120.254",
+    "destination_ip": "",
+    "payload": "<189>date={{TR_DATE_NOW_ONLY}} time={{TR_TIME_NOW_ONLY}} devname=\"{{TR_FG_DEV_NAME}}\" devid=\"{{TR_FGT_SN}}\" logid=\"0954024577\" type=\"utm\" subtype=\"dlp\" eventtype=\"dlp\" level=\"notice\" vd=\"root\" eventtime=1591815494749154664 tz=\"{{TR_TIMEZONE}}\" filteridx=3 filtername=\"watermark_private\" dlpextra=\"\" filtertype=\"watermark\" filtercat=\"file\" severity=\"high\" policyid=5 sessionid=189656 epoch=2125573460 eventid=0 srcip={{TR_ASSET_IP}} srcport=57492 srcintf=\"port3\" srcintfrole=\"lan\" dstip=\"80.222.32.1\" dstport=21 dstintf=\"port2\" dstintfrole=\"dmz\" proto=6 service=\"FTP\" user=\"l.kolbad\" authserver=\"FSSO\" filetype=\"msofficex\" direction=\"outgoing\" action=\"log-only\" filename=\"Traduction.docx\" filesize=96090 profile=\"dlp_profile\" infectedfilename=\"docProps/custom.xml\" infectedfilesize=473 infectedfiletype=\"html\" infectedfilelevel=1"
+  },
+  {
+    "sleep": -1,
+    "name": "Data Leakage Detected",
+    "source": "FSMSIM-Data-Leak-Prevention",
+    "demo_message": "4) Data Leakage: A user sends a file that violates the company policy - a torrent file.\n  a) [Alerts View] User f.baddler sharing a torrent file over the internet.\n  b) [Playbooks Logs] Sharing torrents is against InfoSec policy.\n  c) [Playbooks Logs] Playbook walkthrough.\n  d) [Playbooks Logs > Email Step] Email sent to HR.",
+    "source_ip": "10.16.120.254",
+    "destination_ip": "",
+    "payload": "<189>date={{TR_DATE_NOW_ONLY}} time={{TR_TIME_NOW_ONLY}} devname=\"{{TR_FG_DEV_NAME}}\" devid=\"{{TR_FGT_SN}}\" logid=\"0954024577\" type=\"utm\" subtype=\"dlp\" eventtype=\"dlp\" level=\"notice\" vd=\"root\" eventtime=1591818293024005770 tz=\"{{TR_TIMEZONE}}\" filteridx=5 filtername=\"log_all_files\" dlpextra=\"All_files\" filtertype=\"file-type\" filtercat=\"file\" severity=\"medium\" policyid=5 sessionid=196625 epoch=749638349 eventid=0 srcip={{TR_ASSET_IP}} srcport=57498 srcintf=\"port3\" srcintfrole=\"lan\" dstip={{TR_MALICIOUS_IP}} dstport=21 dstintf=\"port2\" dstintfrole=\"dmz\" proto=6 service=\"FTP\" user=\"f.baddler\" authserver=\"FSSO\" filetype=\"torrent\" direction=\"outgoing\" action=\"log-only\" filename=\"Dark.Tower.torrent\" filesize=11903 profile=\"dlp_profile\""
+  }
+]

--- a/scenarios/FortiSIEM/Malicious_URL_Access/info.json
+++ b/scenarios/FortiSIEM/Malicious_URL_Access/info.json
@@ -1,0 +1,11 @@
+{
+    "publisher": "Sean Coupland: SE",
+    "name": "Malicious URL Access",
+    "product":"fortisiem",
+    "category":"soc_analyst",
+    "version": "1.0.0",
+    "description": "Malicious URL Access to a website",
+    "device_dependency":{"dev_name":"fortigate","dev_ip":"10.16.120.254"},
+    "category": "soc_analyst",
+    "infographic": "https://github..."
+}

--- a/scenarios/FortiSIEM/Malicious_URL_Access/scenario.json
+++ b/scenarios/FortiSIEM/Malicious_URL_Access/scenario.json
@@ -1,0 +1,38 @@
+[
+  {
+    "sleep": -1,
+    "name": "Malicious URL Detected",
+    "source": "FSMSIM-Malicious-URL-Access",
+    "demo_message": "1) Client is connecting to an unknown URL that is not on the block list. This one to be manually blocked.",
+    "source_ip": "10.16.120.254",
+    "destination_ip": "",
+    "payload": "<188>date={{TR_DATE_NOW_ONLY}} time={{TR_TIME_NOW_ONLY}} devname=\"{{TR_FG_DEV_NAME}}\" devid=\"{{TR_FGT_SN}}\" logid=\"0316013056\" type=\"utm\" subtype=\"webfilter\" eventtype=\"ftgd_blk\" level=\"warning\" vd=\"root\" eventtime=1594714477081154589 tz=\"{{TR_TIMEZONE}}\" policyid=39 sessionid=11775126 user=\"jsmith\" authserver=\"FSSO\" srcip={{TR_ASSET_IP}} srcport=53670 srcintf=\"port3\" srcintfrole=\"lan\" dstip=83.223.106.13 dstport=80 dstintf=\"port1\" dstintfrole=\"wan\" proto=6 service=\"HTTP\" hostname=\"www.brainky.net\" profile=\"Monitor-All\" action=\"blocked\" reqtype=\"direct\" url=\"http://www.brainky.net/\" sentbyte=296 rcvdbyte=0 direction=\"outgoing\" msg=\"URL belongs to a denied category in policy\" method=\"domain\" cat=0 catdesc=\"Unrated\" crscore=30 craction=4194304 crlevel=\"high\""
+  },
+  {
+    "sleep": -1,
+    "name": "Malicious URL Detected",
+    "source": "FSMSIM-Malicious-URL-Access",
+    "demo_message": "2) Client is connecting to an unknown URL that is not on the block list. This one to be manually allowed.",
+    "source_ip": "10.16.120.254",
+    "destination_ip": "",
+    "payload": "<188>date={{TR_DATE_NOW_ONLY}} time={{TR_TIME_NOW_ONLY}} devname=\"{{TR_FG_DEV_NAME}}\" devid=\"{{TR_FGT_SN}}\" logid=\"0316013056\" type=\"utm\" subtype=\"webfilter\" eventtype=\"ftgd_blk\" level=\"warning\" vd=\"root\" eventtime=1594714477081154589 tz=\"{{TR_TIMEZONE}}\" policyid=39 sessionid=11775126 user=\"asmith\" authserver=\"FSSO\" srcip={{TR_ASSET_IP}} srcport=53670 srcintf=\"port3\" srcintfrole=\"lan\" dstip=83.223.106.13 dstport=80 dstintf=\"port1\" dstintfrole=\"wan\" proto=6 service=\"HTTP\" hostname=\"brainky.net\" profile=\"Monitor-All\" action=\"blocked\" reqtype=\"direct\" url=\"http://brainky.net/\" sentbyte=296 rcvdbyte=0 direction=\"outgoing\" msg=\"URL belongs to a denied category in policy\" method=\"domain\" cat=0 catdesc=\"Unrated\" crscore=30 craction=4194304 crlevel=\"high\""
+  },
+  {
+    "sleep": -1,
+    "name": "Malicious URL Detected",
+    "source": "FSMSIM-Malicious-URL-Access",
+    "demo_message": "3) Client is connecting to an unknown URL that is already on the block list. This one to be manually allowed.",
+    "source_ip": "10.16.120.254",
+    "destination_ip": "",
+    "payload": "<188>date={{TR_DATE_NOW_ONLY}} time={{TR_TIME_NOW_ONLY}} devname=\"{{TR_FG_DEV_NAME}}\" devid=\"{{TR_FGT_SN}}\" logid=\"0316013056\" type=\"utm\" subtype=\"webfilter\" eventtype=\"ftgd_blk\" level=\"warning\" vd=\"root\" eventtime=1594714477081154589 tz=\"{{TR_TIMEZONE}}\" policyid=39 sessionid=11775126 user=\"bsmith\" authserver=\"FSSO\" srcip={{TR_ASSET_IP}} srcport=53670 srcintf=\"port3\" srcintfrole=\"lan\" dstip=83.223.106.13 dstport=80 dstintf=\"port1\" dstintfrole=\"wan\" proto=6 service=\"HTTP\" hostname=\"thewolves.uk\" profile=\"Monitor-All\" action=\"blocked\" reqtype=\"direct\" url=\"http://thewolves.uk\" sentbyte=296 rcvdbyte=0 direction=\"outgoing\" msg=\"URL belongs to a denied category in policy\" method=\"domain\" cat=0 catdesc=\"Unrated\" crscore=30 craction=4194304 crlevel=\"high\""
+  },
+  {
+    "sleep": -1,
+    "name": "Malicious URL Detected",
+    "source": "FSMSIM-Malicious-URL-Access",
+    "demo_message": "4) Client is connecting to a malicious URL. This will be automatically closed as critical.",
+    "source_ip": "10.16.120.254",
+    "destination_ip": "",
+    "payload": "<188>date={{TR_DATE_NOW_ONLY}} time={{TR_TIME_NOW_ONLY}} devname=\"{{TR_FG_DEV_NAME}}\" devid=\"{{TR_FGT_SN}}\" logid=\"0316013056\" type=\"utm\" subtype=\"webfilter\" eventtype=\"ftgd_blk\" level=\"warning\" vd=\"root\" eventtime=1594714477081154589 tz=\"{{TR_TIMEZONE}}\" policyid=39 sessionid=11775126 user=\"csmith\" authserver=\"FSSO\" srcip={{TR_ASSET_IP}} srcport=53670 srcintf=\"port3\" srcintfrole=\"lan\" dstip={{TR_MALICIOUS_IP}} dstport=80 dstintf=\"port1\" dstintfrole=\"wan\" proto=6 service=\"HTTP\" hostname=\"{{TR_MALICIOUS_DOMAIN}}\" profile=\"Monitor-All\" action=\"blocked\" reqtype=\"direct\" url=\"{{TR_MALICIOUS_URL}}\" sentbyte=296 rcvdbyte=0 direction=\"outgoing\" msg=\"URL belongs to a denied category in policy\" method=\"domain\" cat=0 catdesc=\"Unrated\" crscore=30 craction=4194304 crlevel=\"high\""
+  }
+]

--- a/simulator_files/artifact_factory.py
+++ b/simulator_files/artifact_factory.py
@@ -10,11 +10,12 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 templates_path 		= './'
+config_file		= './config.json'
 malware_hashes 		= './threat_intelligence/malware_hashes.txt'
 malicious_domains	= './threat_intelligence/malicious_domains.txt'
 malicious_ips		= './threat_intelligence/malicious_ips.txt'
 malicious_urls		= './threat_intelligence/malicious_urls.txt'
-SOCSIM_FIFO			= '/tmp/socsim.pipe'
+SOCSIM_FIFO		= '/tmp/socsim.pipe'
 MALWARE_FILE 		= '/tmp/malware.pdf'
 
 
@@ -33,7 +34,7 @@ def get_malicious_file():
 	malicious_file = base64.b64decode(b64_malicious_file)+bytes([random.randint(0, 256),random.randint(0, 256),random.randint(0, 256)])
 	tmp_file = open(MALWARE_FILE, 'wb')
 	tmp_file.write(malicious_file)
-	tmp_file.close()	
+	tmp_file.close()
 	return base64.b64encode(malicious_file).decode("utf-8")
 
 
@@ -59,11 +60,29 @@ def get_username():
 	usernames=["Morgoth","Lúthien","Glorfindel","Beren","Túrin_turambar","Eärendil","Ancalagon","Manwë","Thingol","Húrin","Melian","Glaurung","Mandos","Maglor","Elendil","Círdan","Finarfin","Ulmo","Morwen","Beleg","Niënor_níniel","Finduilas","Orodreth","Carcharoth","Eöl","Ossë","Yavanna","Anárion","Lalaith","Emeldir","Dorlas","Aerin","Rían"]
 	return random.choices(usernames)[0]
 
-def get_fg_mgmt_ip():
-	return "10.200.3.1"
+def get_fgt_mgmt_ip():
+        p = open("config.json", 'r')
+        fg_mgmt_config = p.read()
+        fg_mgmt_config = json.loads(fg_mgmt_config)
+        p.close()
+        fg_mgmt_config = fg_mgmt_config['TR_FG_MGMT_IP']
+        return fg_mgmt_config
 
-def get_fg_dev_name():
-	return "FortiGate-Edge"
+def get_fgt_dev_name():
+        p = open(config_file, 'r')
+        fg_hostname_config = p.read()
+        fg_hostname_config = json.loads(fg_hostname_config)
+        p.close()
+        fg_hostname_config = fg_hostname_config['TR_FG_DEV_NAME']
+        return fg_hostname_config
+
+def get_fgt_sn():
+        p = open("config.json", 'r')
+        sn_config = p.read()
+        sn_config = json.loads(sn_config)
+        p.close()
+        sn_config = sn_config['FGT_SN']
+        return sn_config
 
 def get_asset_ip():
 	return "10.200.3."+str(random.randint(2, 24))
@@ -92,6 +111,19 @@ def get_time_minus_five():
 def get_time_minus_six():
 	return int(time.time()) - random.randint(21600, 21900)
 
+def get_date_now_only():
+        return time.strftime('%Y-%m-%d', time.localtime(time.time()))
+
+def get_time_now_only():
+        return time.strftime('%H:%M:%S', time.localtime(time.time()))
+
+def get_timezone():
+	p = open("config.json", 'r')
+	tz_config = p.read()
+	tz_config = json.loads(tz_config)
+	p.close()
+	tz_config = tz_config['TimeZone']
+	return tz_config
 
 def get_random_integer(start=55555,end=99999):
 	return random.randint(start, end)
@@ -237,12 +269,16 @@ function_dictionary={
 "TR_MALICIOUS_FILE_SHA1":get_malicious_file_sha1,
 "TR_MALICIOUS_FILE_SHA256":get_malicious_file_sha256,
 "TR_FORMATTED_CURRENT_TIME":get_formatted_current_time,
-"TR_FG_MGMT_IP":get_fg_mgmt_ip,
-"TR_FG_DEV_NAME":get_fg_dev_name,
+"TR_FG_MGMT_IP":get_fgt_mgmt_ip,
+"TR_FG_DEV_NAME":get_fgt_dev_name,
+"TR_FGT_SN":get_fgt_sn,
 "TR_ASSET_IP":get_asset_ip,
 "TR_MALICIOUS_IP":get_malicious_ip,
 "TR_NOW":get_time_now,
+"TR_DATE_NOW_ONLY":get_date_now_only,
+"TR_TIME_NOW_ONLY":get_time_now_only,
 "TR_PAST":get_time_past,
+"TR_TIMEZONE":get_timezone,
 "TR_RANDOM_INTEGER":get_random_integer,
 "TR_MALICIOUS_DOMAIN":get_malicious_domains,
 "TR_MALICIOUS_URL":get_malicious_url,

--- a/simulator_files/fortisiem_lib.py
+++ b/simulator_files/fortisiem_lib.py
@@ -8,7 +8,7 @@ from scapy.all import *
 
 
 def send_event(source_ip,destination_ip,payload):
-	try:	
+	try:
 		spoofed_packet = IP(src=source_ip, dst=destination_ip) / UDP(sport=random.randint(30000, 35000), dport=514) / payload
 		send(spoofed_packet)
 	except:
@@ -33,7 +33,7 @@ def unprivileged_send_fsm_event(event,sudo_password):
 	fifo = os.open(SOCSIM_FIFO, os.O_WRONLY)
 	os.write(fifo, event)
 	os.close(fifo)
-		
+
 def send_fsm_event(event):
 	"""Default FortiSIEM send events while the tool is running as root"""
 	try:
@@ -49,11 +49,11 @@ def send_fsm_event(event):
 
 
 def cook_fsm_events(scenario_json):
-	try:	
+	try:
 		template_file = json.dumps(scenario_json)
 		tag_list = re.findall('\{\{(.*?)\}\}',template_file)
 		for tag in tag_list:
-			template_file=template_file.replace('{{'+tag+'}}',str(function_dictionary[tag]()))	
+			template_file=template_file.replace('{{'+tag+'}}',str(function_dictionary[tag]()))
 
 	except:
 		print(bcolors.FAIL+"Couldn't process FortiSIEM template file"+bcolors.ENDC)

--- a/simulator_files/main_lib.py
+++ b/simulator_files/main_lib.py
@@ -49,7 +49,7 @@ def read_json(data):
 			return json_data
 
 def load_scenario_folder(scenario_folder_path,scenario_files):
-	"""loadss the json files within the scenario folder into a single json object"""
+	"""loads the json files within the scenario folder into a single json object"""
 	scenario_data={}
 
 	for file in scenario_files:
@@ -64,7 +64,6 @@ def load_scenario_folder(scenario_folder_path,scenario_files):
 				file_content = f.read()
 			f.close()
 			file_content=json.loads(file_content)
-
 		except IOError:
 			if file == PLAYBOOKS_FILE:
 				scenario_data.update({PLAYBOOKS_FILE:""})
@@ -73,7 +72,7 @@ def load_scenario_folder(scenario_folder_path,scenario_files):
 			exit()
 		except ValueError:
 			print(bcolors.FAIL+"Bad Config file: "+file+" syntax"+bcolors.ENDC)
-			exit()		
+			exit()
 		else:
 			scenario_data.update({file:file_content})
 
@@ -92,7 +91,7 @@ def read_mainconfig():
 		return None
 	except ValueError:
 		print(bcolors.FAIL+"Bad Config file syntax, fall back to command arguments"+bcolors.ENDC)
-		return None		
+		return None
 	else:
 		return mainconfig_file
 
@@ -115,7 +114,7 @@ def unprivileged_send_fsm_event(event,sudo_password):
 	fifo = os.open(SOCSIM_FIFO, os.O_WRONLY)
 	os.write(fifo, event)
 	os.close(fifo)
-		
+
 def send_fsm_event(event):
 	"""Default FortiSIEM send events while the tool is running as root"""
 	try:
@@ -132,11 +131,11 @@ def send_fsm_event(event):
 
 
 def cook_fsm_events(scenario_json):
-	try:	
+	try:
 		template_file = json.dumps(scenario_json)
 		tag_list = re.findall('\{\{(.*?)\}\}',template_file)
 		for tag in tag_list:
-			template_file=template_file.replace('{{'+tag+'}}',str(function_dictionary[tag]()))	
+			template_file=template_file.replace('{{'+tag+'}}',str(function_dictionary[tag]()))
 
 	except:
 		print(bcolors.FAIL+"Couldn't process FortiSIEM template file"+bcolors.ENDC)

--- a/soc_simulator.py
+++ b/soc_simulator.py
@@ -2,7 +2,7 @@
 # Main: CLI
 # FortiSOAR CSE Team
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
-__version__ = "0.2"
+__version__ = "0.201"
 
 import os, sys
 os.chdir(sys.path[0])
@@ -14,7 +14,6 @@ from simulator_files.fortisiem_lib import *
 
 def main():
 	config=read_mainconfig()
-
 	tenant_iri=None
 	parser = argparse.ArgumentParser(
 	prog='ProgramName',
@@ -41,7 +40,7 @@ def main():
 
 		if args.tenant:
 			tenant_iri=lookup_tenant_iri(config['FORTISOAR_IP'],headers,args.tenant)['@id']
-		
+
 		if 'connectors_dependencies' in scenario_data['info.json']:
 			check_connectors_prerequisites(config['FORTISOAR_IP'],headers,scenario_data['info.json']['connectors_dependencies'])
 
@@ -67,7 +66,7 @@ def main():
 
 		alerts,playbooks_definition=cook_alert(config['FORTISOAR_IP'],headers,scenario_data['scenario.json'],malware_hashes,malicious_urls,malicious_ips,malicious_domains,scenario_data['playbooks.json'])
 		#print(json.dumps(playbooks_definition, indent=4, sort_keys=True))
-		upload_playbooks(config['FORTISOAR_IP'],headers,playbooks_definition)		
+		upload_playbooks(config['FORTISOAR_IP'],headers,playbooks_definition)
 
 		if args.step:
 			step=int(args.step) - 1
@@ -88,14 +87,21 @@ def main():
 				print(bcolors.INST+"Step Instructions: \n"+alert['data'][0]['demo_message']+bcolors.ENDC)
 
 	if 'fortisiem' in args.scenario_folder.lower():
+		eventCount = 1
 		for event in cook_fsm_events(scenario_data['scenario.json']):
+			print(bcolors.INST+event['demo_message']+bcolors.ENDC)
 			if len(event['destination_ip']) < 7:
-				print('set dst ip',config['FORTISIEM_IP'])
+				print(bcolors.OKGREEN+'Setting destination IP address to pre-configured FortiSIEM IP:'+bcolors.ENDC,bcolors.MSG+config['FORTISIEM_IP']+bcolors.ENDC)
 				event['destination_ip'] = config['FORTISIEM_IP']
-			print('sending event from',event['source_ip'],' to: ',event['destination_ip'])
+			print(bcolors.OKGREEN+'Sending event from'+bcolors.ENDC,bcolors.MSG+str(event['source_ip'])+bcolors.ENDC,bcolors.OKGREEN+'to:'+bcolors.ENDC,bcolors.MSG+str(event['destination_ip'])+bcolors.ENDC)
 			send_fsm_event(event)
-			if event['sleep'] > 0:
-				time.sleep(event['sleep'])
+			if eventCount < len(cook_fsm_events(scenario_data['scenario.json'])):
+				if event['sleep'] > 0:
+					input(bcolors.MSG+"Sleeping for {} seconds".format(sleep)+bcolors.ENDC)
+					time.sleep(event['sleep'])
+				else:
+					input(bcolors.MSG+"Press Enter key to continue"+bcolors.ENDC)
+			eventCount += 1
 
 if __name__ == '__main__':
 	main()


### PR DESCRIPTION
Converting two of the FSOAR demos into an indirect load method so that they are sent into the FSM instead, which can then be ingested via the FSOAR.

Only missing components are the modified playbooks for FSOAR, and the FSM rules.